### PR TITLE
fix deprecated keymap selector

### DIFF
--- a/keymaps/require.cson
+++ b/keymaps/require.cson
@@ -8,13 +8,13 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 {
-  ".platform-darwin, .platform-darwin .editor": {
+  ".platform-darwin, .platform-darwin .atom-text-editor": {
     "cmd-alt-r": "require:require"
   },
-  ".platform-win32, .platform-win32 .editor": {
+  ".platform-win32, .platform-win32 .atom-text-editor": {
     "ctrl-alt-r": "require:require"
   },
-  ".platform-linux, .platform-linux .editor": {
+  ".platform-linux, .platform-linux .atom-text-editor": {
     "ctrl-alt-r": "require:require"
   }
 }


### PR DESCRIPTION
Fixes the deprecated selector warning in atom
